### PR TITLE
TOOLS-1376 when looking for server-setup jobs, only get server-setup jobs

### DIFF
--- a/tools/bin/sdc-server
+++ b/tools/bin/sdc-server
@@ -6,7 +6,7 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 //
@@ -231,7 +231,7 @@ function outputServerData(servers, callback)
             // setup job is currently running
             setup_state = 'running';
 
-            getJobs(s.uuid, function (err, jobs) {
+            getJobs(s.uuid, { name: 'server-setup*' }, function (err, jobs) {
                 var newest = 0;
 
                 if (err) {
@@ -242,12 +242,15 @@ function outputServerData(servers, callback)
                 jobs.forEach(function (job) {
                     var start;
 
-                    if (job.name.match(/^server-setup/)) {
-                        start = new Date(job.created_at).getTime();
-                        if (start > newest) {
-                            setup_state = job.execution;
-                            newest = start;
-                        }
+                    // our query had name=server-setup* so we shouldn't see any
+                    // other name.
+                    assert.ok(job.name.match(/^server-setup/),
+                        'got incorrect results from workflow: ' + job.name);
+
+                    start = new Date(job.created_at).getTime();
+                    if (start > newest) {
+                        setup_state = job.execution;
+                        newest = start;
                     }
                 });
 
@@ -723,7 +726,7 @@ function deleteServer(server_uuid, callback)
     ], callback);
 }
 
-function getJobs(server_uuid, callback)
+function getJobs(server_uuid, opts, callback)
 {
     var result_jobs = [];
     var wfapi;
@@ -739,14 +742,11 @@ function getJobs(server_uuid, callback)
                 cb(err);
             });
         }, function (cb) {
-            var endpoint = '/jobs?server_uuid=' + server_uuid;
+            var endpoint = '/jobs?target=' + server_uuid;
 
-            /*
-             * Note: WFAPI doesn't support querying on 'target' (WORKFLOW-91)
-             * but it does support querying on params, so we look for all jobs
-             * with server_uuid matching our server and then filter only those
-             * results for the target also matching.
-             */
+            if (opts && opts.name) {
+                endpoint = endpoint + '&name=' + opts.name;
+            }
 
             wfapi.get(endpoint, function (err, req, res, jobs) {
                 if (err) {
@@ -755,11 +755,7 @@ function getJobs(server_uuid, callback)
                     return;
                 }
 
-                jobs.forEach(function (job) {
-                    if (job.target === server_uuid) {
-                        result_jobs.push(job);
-                    }
-                });
+                result_jobs = jobs;
                 cb();
             });
         }
@@ -774,7 +770,7 @@ function getJobs(server_uuid, callback)
 
 function outputJobs(server_uuid, callback)
 {
-    getJobs(server_uuid, function (err, jobs) {
+    getJobs(server_uuid, {}, function (err, jobs) {
         if (err) {
             callback(err);
             return;

--- a/tools/bin/sdc-server
+++ b/tools/bin/sdc-server
@@ -178,6 +178,16 @@ function getNics(server_uuid, params, callback)
 
 function outputServerData(servers, callback)
 {
+    /*
+     * Since workflow orders jobs in descending order based on created_at and
+     * we're passing in the name 'server-setup*' we'll get the newest one first.
+     * That's the only one we care about here, so we limit=1.
+     */
+    var getJobOpts = {
+        limit: 1,
+        name: 'server-setup*'
+    };
+
     console.log(sprintf('%-20s %-36s %7s %8s  %8s  %7s  %-15s',
         'HOSTNAME', 'UUID', 'VERSION', 'SETUP', 'STATUS', 'RAM', 'ADMIN_IP'));
 
@@ -231,28 +241,27 @@ function outputServerData(servers, callback)
             // setup job is currently running
             setup_state = 'running';
 
-            getJobs(s.uuid, { name: 'server-setup*' }, function (err, jobs) {
-                var newest = 0;
+            getJobs(s.uuid, getJobOpts, function (err, jobs) {
+                var job;
 
                 if (err) {
                     callback(err);
                     return;
                 }
 
-                jobs.forEach(function (job) {
-                    var start;
+                if (jobs.length === 1) {
+                    job = jobs[0];
 
                     // our query had name=server-setup* so we shouldn't see any
                     // other name.
                     assert.ok(job.name.match(/^server-setup/),
                         'got incorrect results from workflow: ' + job.name);
 
-                    start = new Date(job.created_at).getTime();
-                    if (start > newest) {
-                        setup_state = job.execution;
-                        newest = start;
-                    }
-                });
+                    setup_state = job.execution;
+                } else {
+                    console.error('WARNING: unable to find setup job for '
+                        + s.uuid);
+                }
 
                 outputLine();
             });
@@ -728,6 +737,12 @@ function deleteServer(server_uuid, callback)
 
 function getJobs(server_uuid, opts, callback)
 {
+    assert.string(server_uuid, 'server_uuid');
+    assert.object(opts, 'opts');
+    assert.optionalNumber(opts.limit, 'opts.limit');
+    assert.optionalString(opts.name, 'opts.name');
+    assert.func(callback, 'callback');
+
     var result_jobs = [];
     var wfapi;
 
@@ -746,6 +761,10 @@ function getJobs(server_uuid, opts, callback)
 
             if (opts && opts.name) {
                 endpoint = endpoint + '&name=' + opts.name;
+            }
+
+            if (opts && opts.limit) {
+                endpoint = endpoint + '&limit=' + opts.limit;
             }
 
             wfapi.get(endpoint, function (err, req, res, jobs) {


### PR DESCRIPTION
This adds name=server-setup* to the query parameters when looking up jobs for a server. Along the way I also fixed the loading of target since WORKFLOW-91 implemented that.