### PR TITLE
TRITON-2234 ISO install broke with LinuxCN changes

### DIFF
--- a/scripts/joysetup.sh
+++ b/scripts/joysetup.sh
@@ -479,6 +479,7 @@ function create_zpool
         # shellcheck disable=SC2086
         if mkzpool -B -f ${e_flag} "${SYS_ZPOOL}" "${POOL_JSON}"; then
             printf "\n%-56s          (as potentially bootable)" "" >&4
+	    bootable=yes
         elif ! mkzpool -f ${e_flag} "${SYS_ZPOOL}" "${POOL_JSON}"; then
             printf "%6s\n" "failed" >&4
             fatal "failed to create pool"


### PR DESCRIPTION
Sorry for missing this in code-review, an assignment for "bootable=yes" was missed/mismerged during Linux CN work.