### PR TITLE
TRITON-xxxx Headnode installer now fully in 2026

### DIFF
--- a/scripts/prompt-config.sh
+++ b/scripts/prompt-config.sh
@@ -8,7 +8,7 @@
 #
 # Copyright 2022 Joyent, Inc.
 # Copyright 2025 MNX Cloud, Inc.
-# Copyright 2025 Edgecast Cloud LLC.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 # XXX - TODO
@@ -887,7 +887,7 @@ export TERM=xterm-color
 
 trap sig_doshell SIGINT
 
-printheader "Copyright 2025 Edgecast Cloud"
+printheader "Copyright 2026 Edgecast Cloud"
 
 message="
 Before proceeding with the installation of Triton please familiarise yourself


### PR DESCRIPTION
Feels like this should be something with %%YEAR%% in it and we update it at "make" time.